### PR TITLE
Replace ft.yml with CODEOWNERS file

### DIFF
--- a/ft.yml
+++ b/ft.yml
@@ -1,3 +1,0 @@
-owner:
-  github:
-  email:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/main.js",
   "repository": "Financial-Times/n-jsonp",
   "devDependencies": {
-    "@financial-times/n-gage": "^1.7.0",
+    "@financial-times/n-gage": "^3.5.0",
     "bower": "^1.8.0",
     "chai": "^4.0.2",
     "eslint": "^4.0.0",


### PR DESCRIPTION
This PR replaces our custom `ft.yml` file with GitHub's standard CODEOWNERS file. The CODEOWNERS file defines the individual or team that is responsible for the code in the repository. Unlike `ft.yml`, code owners will automatically be asked to review any pull requests.

For more information on CODEOWNERS, see https://help.github.com/en/articles/about-code-owners.

Where a repository contains an empty `ft.yml`, no CODEOWNERS file will be created. We did this so we can easily identify which repositories are unowned by looking for the absence of a CODEOWNERS file.

The n-gage package insists that repositories have an ft.yml file. Version 3.4.0 of n-gage removes this requirement. This transformation requires n-gage version 3.4.0 in package.json because it deletes the (otherwise required) ft.yml file.
