### PR TITLE
Add Synk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.2.0",
     "npm-prepublish": "^1.2.2",
+    "snyk": "^1.169.0",
     "supertest": "^3.0.0",
     "webpack": "^2.6.1"
   },
@@ -30,6 +31,7 @@
     "commit": "commit-wizard",
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "prepush": "make verify -j3"
+    "prepush": "make verify -j3",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   }
 }


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building.

See https://github.com/Financial-Times/next/issues/365